### PR TITLE
ShortestPath memory improvement

### DIFF
--- a/path.go
+++ b/path.go
@@ -42,23 +42,36 @@ func ShortestPaths(g Iterator, v int) (parent []int, dist []int64) {
 	// Dijkstra's algorithm
 	Q := emptyPrioQueue(dist)
 	Q.Push(v)
+	p := &pathFinder{dist: dist, parent: parent, Q: Q}
+	do := p.Do
 	for Q.Len() > 0 {
 		v := Q.Pop()
-		g.Visit(v, func(w int, d int64) (skip bool) {
-			if d < 0 {
-				return
-			}
-			alt := dist[v] + d
-			switch {
-			case dist[w] == -1:
-				dist[w], parent[w] = alt, v
-				Q.Push(w)
-			case alt < dist[w]:
-				dist[w], parent[w] = alt, v
-				Q.Fix(w)
-			}
-			return
-		})
+		p.v = v
+		g.Visit(v, do)
+	}
+	return
+}
+
+type pathFinder struct {
+	dist   []int64
+	parent []int
+	Q      *prioQueue
+	v      int
+}
+
+// Do performs a part of the shortest path algorithm.
+func (p *pathFinder) Do(w int, d int64) (skip bool) {
+	if d < 0 {
+		return
+	}
+	alt := p.dist[p.v] + d
+	switch {
+	case p.dist[w] == -1:
+		p.dist[w], p.parent[w] = alt, p.v
+		p.Q.Push(w)
+	case alt < p.dist[w]:
+		p.dist[w], p.parent[w] = alt, p.v
+		p.Q.Fix(w)
 	}
 	return
 }


### PR DESCRIPTION
Hi Korthaj, when i was using the ShortestPath function i noticed that it was using a significant amount of memory (I was processing a large graph).
It seems that the closure is allocated (or a pointer to it) at each iteration of the loop which makes the function use more memory.

```
name             old time/op    new time/op    delta
ShortestPaths-8     154µs ± 0%      85µs ± 0%  -45.02%

name             old alloc/op   new alloc/op   delta
ShortestPaths-8    81.0kB ± 0%    41.1kB ± 0%  -49.26%

name             old allocs/op  new allocs/op  delta
ShortestPaths-8       849 ± 0%        17 ± 0%  -98.00%
```

This package and your blog are awsome.

-Rodrigo