### PR TITLE
Make mutable graph visitation order deterministic, add go.mod/sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/jhickner/graph
+
+go 1.19
+
+require (
+	github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869
+	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869 h1:7v7L5lsfw4w8iqBBXETukHo4IPltmD+mWoLRYUmeGN8=
+github.com/yourbasic/graph v0.0.0-20210606180040-8ecfec1c2869/go.mod h1:Rfzr+sqaDreiCaoQbFCu3sTXxeFq/9kXRuyOoSlGQHE=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea h1:vLCWI/yYrdEHyN2JzIzPO3aaQJHQdp89IZBA/+azVC4=
+golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/mutable.go
+++ b/mutable.go
@@ -1,7 +1,10 @@
 package graph
 
 import (
+	"sort"
 	"strconv"
+
+	"golang.org/x/exp/maps"
 )
 
 const initialMapSize = 4
@@ -11,7 +14,6 @@ const initialMapSize = 4
 // The implementation uses hash maps to associate each vertex in the graph with
 // its adjacent vertices. This gives constant time performance for
 // all basic operations.
-//
 type Mutable struct {
 	// The map edges[v] contains the mapping {w:c} if there is an edge
 	// from v to w, and c is the cost assigned to this edge.
@@ -85,12 +87,15 @@ func (g *Mutable) Order() int {
 // If do returns true, Visit returns immediately,
 // skipping any remaining neighbors, and returns true.
 //
-// The iteration order is not specified and is not guaranteed
-// to be the same every time.
+// The iteration order is deterministic.
 // It is safe to delete, but not to add, edges adjacent to v
 // during a call to this method.
 func (g *Mutable) Visit(v int, do func(w int, c int64) bool) bool {
-	for w, c := range g.edges[v] {
+	keys := maps.Keys(g.edges[v])
+	sort.Ints(keys)
+
+	for _, w := range keys {
+		c := g.edges[v][w]
 		if do(w, c) {
 			return true
 		}


### PR DESCRIPTION
I ran into an issue caused by the non-deterministic ordering of `Visit`. This change first sorts the map keys, making the order deterministic. I also added go.mod and go.sum files.